### PR TITLE
Using a more correct way to build multi-release sources, by using --patch-module.

### DIFF
--- a/.bach/src/run.bach/run/bach/project/CompileModulesTool.java
+++ b/.bach/src/run.bach/run/bach/project/CompileModulesTool.java
@@ -16,6 +16,7 @@ import run.bach.ToolOperator;
 public class CompileModulesTool implements ToolOperator {
 
   static final String NAME = "compile-modules";
+  private static final String PATH_SEPARATOR = System.getProperty("path.separator");
 
   public CompileModulesTool() {}
 
@@ -124,12 +125,14 @@ public class CompileModulesTool implements ToolOperator {
         var javac = ToolCall.of("javac").with("--release", release);
         var modulePath = context.space().toModulePath(context.bach().paths());
         if (modulePath.isPresent()) {
-          javac = javac.with("--module-path", modulePath.get());
+          javac = javac.with("--module-path", modulePath.get() + PATH_SEPARATOR + classes0);
           javac = javac.with("--processor-module-path", modulePath.get());
+        } else {
+          javac = javac.with("--module-path", classes0);
         }
         javac =
             javac
-                .with("--class-path", classes0.resolve(name))
+                .with("--patch-module", module.name() + "=" + sources)
                 .with("-implicit:none")
                 .with("-d", classesR)
                 .withFindFiles(sources, "**.java");


### PR DESCRIPTION
Using `--class-path` to build multi-release sources seems clearly wrong (as `--class-path` is an unnamed module, not the named module that is being compiled - this means that either the module rules are not being followed, or the baseline class are not available, depending on what exact sources are in the multi-release sources). `--patch-module` is, to the best of my knowledge, the correct way to handle building of module parts that are outside of the main module.